### PR TITLE
Enforce dump usage in version migration

### DIFF
--- a/scripts/update_meilisearch_version.sh
+++ b/scripts/update_meilisearch_version.sh
@@ -221,7 +221,7 @@ echo "${INFO_LABEL}Copy data.ms to be able to recover in case of failure."
 
 # Remove data.ms
 rm -rf /var/lib/meilisearch/data.ms
-echo "${INFO_LABEL}Delete current MeiliSearch's data.m."
+echo "${INFO_LABEL}Delete current MeiliSearch's data.ms"
 
 # Run MeiliSearch
 MEILI_IMPORT_DUMP="/dumps/$dump_id.dump"

--- a/scripts/update_meilisearch_version.sh
+++ b/scripts/update_meilisearch_version.sh
@@ -38,7 +38,7 @@ previous_version_rollback() {
 
 # Check if MeiliSearch systemctl process is Active
 systemctl_status() {
-    systemctl status meilisearch | grep -E 'Active: active \(running\)'
+    systemctl status meilisearch | grep -E 'Active: active \(running\)' -q
     grep_status_code=$?
     callback_1=$1
     callback_2=$2

--- a/scripts/update_meilisearch_version.sh
+++ b/scripts/update_meilisearch_version.sh
@@ -14,6 +14,7 @@ ERROR_LABEL="${BRED}error: ${NC}"
 SUCCESS_LABEL="${BGREEN}success: ${NC}"
 PENDING_LABEL="${BYELLOW}pending: ${NC}"
 INFO_LABEL="${BBLUE}info: ${NC}"
+WARNING_LABEL="${BYELLOW}warning: ${NC}"
 
 ## Utils Functions
 
@@ -32,7 +33,8 @@ previous_version_rollback() {
     systemctl_status exit
     echo "${SUCCESS_LABEL}Previous MeiliSearch version ${BPINK}$current_meilisearch_version${NC} restarted correctly with its data recovered." >&2
     delete_temporary_files
-    echo "${ERROR_LABEL}Update MeiliSearch from ${BPINK}$current_meilisearch_version${NC} to ${BPINK}$meilisearch_version${NC} failed. Rollback to previous version successfull." >&2
+    echo "${WARNING_LABEL}Update MeiliSearch from ${BPINK}$current_meilisearch_version${NC} to ${BPINK}$meilisearch_version${NC} failed. Rollback to previous version successfull." >&2
+    echo "${BGREEN}MeiliSearch service up and running in version ${NC} ${BPINK}$meilisearch_version${NC}."
     exit
 }
 
@@ -62,7 +64,7 @@ delete_temporary_files() {
         echo "${SUCCESS_LABEL}Delete temporary meilisearch binary."
     fi
 
-    if [ -d "logs" ]; then
+    if [ -f "logs" ]; then
         rm logs
         echo "${SUCCESS_LABEL}Delete temporary logs file."
     fi
@@ -216,7 +218,6 @@ echo "${INFO_LABEL}Update MeiliSearch version."
 cp meilisearch /usr/bin/meilisearch
 
 # Run MeiliSearch
-MEILI_IMPORT_DUMP="/dumps/$dump_id.dump"
 ./meilisearch --db-path /var/lib/meilisearch/data.ms --env production --import-dump "/dumps/$dump_id.dump" --master-key $MEILISEARCH_MASTER_KEY 2>logs &
 echo "${INFO_LABEL}Run local $meilisearch_version binary importing the dump and creating the new data.ms."
 
@@ -261,3 +262,4 @@ echo "${SUCCESS_LABEL}MeiliSearch $meilisearch_version service started succesful
 delete_temporary_files
 
 echo "${BGREEN}Migration complete. MeiliSearch is now in version ${NC} ${BPINK}$meilisearch_version${NC}."
+echo "${BGREEN}MeiliSearch service up and running in version ${NC} ${BPINK}$meilisearch_version${NC}."

--- a/scripts/update_meilisearch_version.sh
+++ b/scripts/update_meilisearch_version.sh
@@ -203,25 +203,17 @@ systemctl stop meilisearch # stop the service to update the version
 echo "${INFO_LABEL}Keep a temporary copy of previous MeiliSearch."
 mv /usr/bin/meilisearch /tmp
 
-## Copy
-echo "${INFO_LABEL}Update MeiliSearch version."
-cp meilisearch /usr/bin/meilisearch
-
-## Restart MeiliSearch
-systemctl restart meilisearch
-echo "${INFO_LABEL}MeiliSearch $meilisearch_version is starting."
-
-# Stopping MeiliSearch Service
-systemctl stop meilisearch
-echo "${INFO_LABEL}Stop MeiliSearch $meilisearch_version service."
-
 # Keep cache of previous data.ms in case of failure
 cp -r /var/lib/meilisearch/data.ms /tmp/
-echo "${INFO_LABEL}Copy data.ms to be able to recover in case of failure."
+echo "${INFO_LABEL}Keep a temporary copy of previous data.ms."
 
 # Remove data.ms
 rm -rf /var/lib/meilisearch/data.ms
 echo "${INFO_LABEL}Delete current MeiliSearch's data.ms"
+
+## Move new MeiliSearch binary to the systemctl directory containing the binary
+echo "${INFO_LABEL}Update MeiliSearch version."
+cp meilisearch /usr/bin/meilisearch
 
 # Run MeiliSearch
 MEILI_IMPORT_DUMP="/dumps/$dump_id.dump"
@@ -250,19 +242,20 @@ else
         echo "${PENDING_LABEL}MeiliSearch is still indexing the dump."
         sleep 2
     done
-
     echo "${SUCCESS_LABEL}MeiliSearch is done indexing the dump."
-    # Kill local MeiliSearch process
-    pkill meilisearch
-    echo "${INFO_LABEL}Kill local MeiliSearch process."
 
-    # Restart MeiliSearch
-    systemctl restart meilisearch
-    echo "${INFO_LABEL}MeiliSearch $meilisearch_version service is starting."
-    # In case of failed restart rollback to initial version
-    systemctl_status previous_version_rollback exit
-    echo "${SUCCESS_LABEL}MeiliSearch $meilisearch_version service started succesfully."
+    # Kill local MeiliSearch process
+    echo "${INFO_LABEL}Kill local MeiliSearch process."
+    pkill meilisearch
 fi
+
+## Restart MeiliSearch
+systemctl restart meilisearch
+echo "${INFO_LABEL}MeiliSearch $meilisearch_version is starting."
+
+# In case of failed restart rollback to initial version
+systemctl_status previous_version_rollback exit
+echo "${SUCCESS_LABEL}MeiliSearch $meilisearch_version service started succesfully."
 
 # Delete temporary files to leave the environment the way it was initially
 delete_temporary_files


### PR DESCRIPTION
Because of inconsistency in keeping data.ms between versions upgrades. Where sometimes all indexes would be deleted. We decided to always use the dumps importation system to ensure keeping data. 