### PR TITLE
Fix compatibility message after Meilisearch v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ See our [Documentation](https://docs.meilisearch.com/learn/tutorials/getting_sta
 
 ## 🤖 Compatibility with Meilisearch
 
-This package only guarantees the compatibility with the [version v1.0.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0).
+This package guarantees compatibility with [version v1.x of Meilisearch](https://github.com/meilisearch/meilisearch/releases/latest), but some features may not be present. Please check the [issues](https://github.com/meilisearch/meilisearch-migration/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3Aenhancement) for more info.
 
 ## ⚙️ Development Workflow and Contributing
 


### PR DESCRIPTION
Related to this issue: meilisearch/integration-guides#237

Based on the discussion from the integration-guides issue, this is now the default message for Meilisearch v1 era.
