### PR TITLE
Add a migration script that safely updates Meilisearch

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,37 @@
+## update_meilisearch_version_safely.sh
+
+### Requirements
+
+1. Systemd-based distribution.
+2. Nginx Reverse proxy.
+3. jq JSON processor.
+4. A Running Meilisearch instance.
+5. Disable writes before running a script.
+
+### Description
+The script installs the new version of Meilisearch on a different port as an additional systemd service. It makes a dump from the current version and restores it to the new one.
+After restoring a backup, it checks the health of the new version. if everything is successful, it replaces the port in the Nginx server block to direct traffic to a new version. 
+Then it stops the original version.
+
+Advantages:
+- the original version of Meilisearch remains intact: data, executable, configuration.
+- the Meilisearch instance continues serving read queries during an updating process.
+
+Caveats:
+If writes are not disabled, data synchronization is needed to copy changes made to the original version during an updating process. To disable all queries, set 
+CURRENT_MEILISEARCH_STOP=true if there are no requirements to have read queries available during an update.
+
+### Usage
+
+1. Open *update_meilisearch_version_safely.sh* and update variables specific to your deployment.
+2. Disable writes (see "Caveats").
+3. Run the following script
+
+```bash
+bash update_meilisearch_version_safely.sh
+```
+
+4. After update, cleanup the resources for the original version (data, executable, configuration)
+
+### Tests
+v0.26.0 -> v1.0.0, AWS deployment with Meilisearch AMI.

--- a/scripts/update_meilisearch_version_safely.sh
+++ b/scripts/update_meilisearch_version_safely.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+# The master key of current and new Meilisearch versions
+MEILISEARCH_MASTER_KEY=
+# The system user for running the new Meilisearch version
+MEILISEARCH_USER=meilisearch
+
+# The dir where the current Meilisearch version stores dumps
+CURRENT_MEILISEARCH_DUMP_DIR=/var/opt/meilisearch/dumps
+# The port of the current Meilisearch version
+CURRENT_MEILISEARCH_PORT=7700
+# The name of the systemd service of the current Meilisearch version
+CURRENT_MEILISEARCH_SERVICE=meilisearch.service
+# To stop the current version of Meilisearch after making a dump.
+CURRENT_MEILISEARCH_STOP=false
+
+# The port of the new Meilisearch version 
+NEW_MEILISEARCH_PORT=7701
+# The version of the new Meilisearch to install
+NEW_MEILISEARCH_VERSION=v1.0.0
+
+# The Nginx configuration file with Reverse Proxy settings for Meilisearch.
+# After the migration, the port number $CURRENT_MEILISEARCH_PORT will be 
+# replaces with $NEW_MEILISEARCH_PORT and Nginx process will be reloaded.
+NGINX_CONFIG=/etc/nginx/sites-enabled/meilisearch
+
+log() { echo -e "[log]: $1" ;}
+
+# 
+# Validate input.
+#
+
+[ -z "$MEILISEARCH_MASTER_KEY" ] && unset MEILISEARCH_MASTER_KEY
+
+# 
+# Create and prepare dump from the current Meilisearch version
+#
+
+log "Start dump creation."
+response=$(curl -sS --fail -X POST "http://localhost:7700/dumps" -H "Authorization: Bearer $MEILISEARCH_MASTER_KEY")
+dump_uid=$(jq -r '.uid' <<< $response)
+log "Dump uid: $dump_uid"
+
+log "Wait until dump is ready."
+while true; do
+  response=$(curl -sS -X GET "http://localhost:7700/dumps/$dump_uid/status" -H "Authorization: Bearer $MEILISEARCH_MASTER_KEY")
+  status=$(jq -r '.status' <<< $response)
+  if [ "$status" == "done" ]; then
+    log "Dump is created."
+    break
+  fi
+  log "Status of a dump creation process: $status"
+  sleep 5
+done
+
+dump_file="$CURRENT_MEILISEARCH_DUMP_DIR/$dump_uid.dump"
+log "Dump location: $dump_file"
+
+if [ "$CURRENT_MEILISEARCH_STOP" == "true" ]; then
+  log "Stop the current version of Meilisearch after making a dump."
+  systemctl stop $CURRENT_MEILISEARCH_SERVICE
+  log "Stopped."
+fi
+
+# 
+# Install and configure a new systemd service for running the new Meilisearch version
+#
+
+log "Download Meilisearch $NEW_MEILISEARCH_VERSION binary."
+curl -sSL "https://github.com/meilisearch/meilisearch/releases/download/$NEW_MEILISEARCH_VERSION/meilisearch-linux-amd64" -o meilisearch-$NEW_MEILISEARCH_VERSION
+chmod +x meilisearch-$NEW_MEILISEARCH_VERSION
+mv meilisearch-$NEW_MEILISEARCH_VERSION /usr/local/bin
+log "Done."
+
+mkdir -p /var/lib/meilisearch-$NEW_MEILISEARCH_VERSION/{data,dumps,snapshots}
+
+cat << EOF > /etc/meilisearch.toml
+env = "production"
+master_key = "$MEILISEARCH_MASTER_KEY"
+db_path = "/var/lib/meilisearch-$NEW_MEILISEARCH_VERSION/data"
+dump_dir = "/var/lib/meilisearch-$NEW_MEILISEARCH_VERSION/dumps"
+snapshot_dir = "/var/lib/meilisearch-$NEW_MEILISEARCH_VERSION/snapshots"
+http_addr = "localhost:$NEW_MEILISEARCH_PORT"
+EOF
+
+cat << EOF > /etc/systemd/system/meilisearch-$NEW_MEILISEARCH_VERSION.service
+[Unit]
+Description=Meilisearch
+After=systemd-user-sessions.service
+
+[Service]
+Type=simple
+WorkingDirectory=/var/lib/meilisearch-$NEW_MEILISEARCH_VERSION
+ExecStart=/usr/local/bin/meilisearch-$NEW_MEILISEARCH_VERSION --config-file-path /etc/meilisearch.toml --import-dump $dump_file
+User=$MEILISEARCH_USER
+Group=$MEILISEARCH_USER
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl daemon-reload
+
+id -u $MEILISEARCH_USER &>/dev/null || useradd -d /var/lib/meilisearch -b /bin/false -M -r $MEILISEARCH_USER
+chown -R $MEILISEARCH_USER:$MEILISEARCH_USER /var/lib/meilisearch-$NEW_MEILISEARCH_VERSION
+chmod 750 /var/lib/meilisearch-$NEW_MEILISEARCH_VERSION 
+chown $MEILISEARCH_USER:$MEILISEARCH_USER $dump_file
+
+# 
+# Start the new Meilisearch version and begin the restoration process
+#
+
+log "Start meilisearch-$NEW_MEILISEARCH_VERSION.service and begin the restoration process."
+systemctl start meilisearch-$NEW_MEILISEARCH_VERSION
+
+sed -i 's/--import-dump [^ ]*//' /etc/systemd/system/meilisearch-$NEW_MEILISEARCH_VERSION.service
+systemctl daemon-reload
+systemctl enable meilisearch-$NEW_MEILISEARCH_VERSION
+systemctl status --no-pager meilisearch-$NEW_MEILISEARCH_VERSION
+
+log "Wait until Meilisearch $NEW_MEILISEARCH_VERSION is up and healthy."
+while true; do
+  service_state=$(systemctl is-active meilisearch-$NEW_MEILISEARCH_VERSION.service || :)
+  log "The meilisearch-$NEW_MEILISEARCH_VERSION.service is in $service_state state."
+  if [ "$service_state" != "active" ]; then
+    log "The import operation failed. Check meilisearch-$NEW_MEILISEARCH_VERSION.service logs."
+    exit 1
+  fi
+
+  response=$(curl -sS --fail -X GET "http://localhost:$NEW_MEILISEARCH_PORT/health" -H "Authorization: Bearer $MEILISEARCH_MASTER_KEY" 2>/dev/null) && exist_code="$?" || exist_code="$?" 
+  if [ $exist_code -ne 0 ]; then 
+    log "Meilisearch $NEW_MEILISEARCH_VERSION is still importing data."
+    sleep 15
+  else 
+    status=$(jq -r '.status' <<< $response)
+    if [ "$status" == "available" ]; then
+      log "Meilisearch $NEW_MEILISEARCH_VERSION is up and healthy."
+      break 
+    fi
+  fi
+done
+log "The restoration process is finished."
+
+#
+# Route traffic to a new Meilisearch version by changing the port in the proxy_pass directive.
+# 
+
+log "Update Nginx server block to direct traffic to Meilisearch $NEW_MEILISEARCH_VERSION"
+sed -i "s/$CURRENT_MEILISEARCH_PORT/$NEW_MEILISEARCH_PORT/g" $NGINX_CONFIG
+nginx -s reload
+
+#
+# Turn off the original version of Meilisearch.
+# 
+
+log "Stop and disable the original Meilisearch version."
+systemctl stop $CURRENT_MEILISEARCH_SERVICE
+systemctl disable $CURRENT_MEILISEARCH_SERVICE
+log "Done."


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Adds a script for Meilisearch updates with the following advantages:
   - the original version of Meilisearch remains intact: data, executable, and configuration files.
   - simple rollback: bring up the original version of Meilisearch and switch ports in the Nginx server block.
   - (optional) the Meilisearch instance can continue serving read queries during an updating process if you block all writes.

The script is tested for v0.26.0 -> v1.0.0 update and should be operational for environments that use systemd-based distribution.