### PR TITLE
Update dumps directory to match the default

### DIFF
--- a/scripts/update_meilisearch_version.sh
+++ b/scripts/update_meilisearch_version.sh
@@ -69,7 +69,7 @@ delete_temporary_files() {
         echo -e "${SUCCESS_LABEL}Delete temporary logs file."
     fi
 
-    local dump_file="/var/opt/meilisearch/dumps/$dump_id.dump"
+    local dump_file="/dumps/$dump_id.dump"
     if [ -f $dump_file ]; then
         rm "$dump_file"
         echo -e "${SUCCESS_LABEL}Delete temporary dump file."
@@ -258,7 +258,7 @@ cp meilisearch /usr/bin/meilisearch
 # Run Meilisearch
 # TODO: `import-dump` may change name for v1, it should be added in the integration-guide issue
 # https://github.com/meilisearch/meilisearch/issues/3132
-./meilisearch --db-path /var/lib/meilisearch/data.ms --env production --import-dump "/var/opt/meilisearch/dumps/$dump_id.dump" --master-key $MEILISEARCH_MASTER_KEY 2>logs &
+./meilisearch --db-path /var/lib/meilisearch/data.ms --env production --import-dump "/dumps/$dump_id.dump" --master-key $MEILISEARCH_MASTER_KEY 2>logs &
 echo -e "${INFO_LABEL}Run local $meilisearch_version binary importing the dump and creating the new data.ms."
 
 sleep 2
@@ -309,6 +309,7 @@ then
 fi
 
 ## Restart Meilisearch
+systemctl daemon-reload
 systemctl restart meilisearch
 echo -e "${INFO_LABEL}Meilisearch $meilisearch_version is starting."
 


### PR DESCRIPTION
## What does this PR do?
The migration script currently makes the assumption that the dumps directory is configured as `/var/opt/meilisearch/dumps`, but this is not the case by default and it's also not documented in the migration script documentation. I believe assuming minimal configuration will provide a better experience for _most_ users. Ideally the user could provide their configured dumps directory and the script would use that, but for that we first need to add support for arguments in general and I considered it out of scope for this small change.

I've also added a `systemctl daemon-reload` line before the final service restart to get rid of systemctl warnings after the upgrade.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
