### PR TITLE
Update binary corruption detection to be more flexible

### DIFF
--- a/scripts/update_meilisearch_version.sh
+++ b/scripts/update_meilisearch_version.sh
@@ -224,7 +224,7 @@ check_last_exit_status $? \
 chmod +x meilisearch
 
 # Check if Meilisearch binary is not corrupted
-if file meilisearch | grep "ELF 64-bit LSB shared object" -q; then
+if file meilisearch | grep "ELF 64-bit LSB" -q; then
     echo -e "${SUCCESS_LABEL}Successfully downloaded Meilisearch version $meilisearch_version."
 else
     echo -e "${ERROR_LABEL}Meilisearch binary is corrupted.\n\


### PR DESCRIPTION
## What does this PR do?
When trying to use the migration script to migrate from version 1.2.0 to 1.3.1, I encountered the "Meilisearch binary is corrupted" error message. My binary wasn't corrupted however, it was just that it contained a different text after `ELF 64-bit LSB`. Will checking just for `ELF 64-bit LSB` be enough to verify the binary?

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?